### PR TITLE
Add fuzzy matching for country names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2
+- add fuzzy matching for country names
+
 ## 1.1.1
 - fix issue with static data file not included in dist
 

--- a/django_countries_hdx/__init__.py
+++ b/django_countries_hdx/__init__.py
@@ -251,4 +251,17 @@ class Regions:
                 return None
         return None
 
+    def fuzzy_match(self, country: str) -> tuple[object | None, bool]:
+        """Attempts to fuzzy match on country name
+
+        :param country: country name to match.
+        :return: tuple(ISO2 code or None, bool indicating whether the match is exact or not)
+        """
+        country_data = HDX.get_iso3_country_code_fuzzy(country)
+
+        if country_data[0] is None:
+            return None, True
+
+        return HDX.get_iso2_from_iso3(country_data[0]), country_data[1]
+
 regions = Regions()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-countries-hdx"
-version = "1.1.1"
+version = "1.2"
 description = "Adds extra M49 data to django-countries using hdx-python-country."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_django_countries_hdx.py
+++ b/tests/test_django_countries_hdx.py
@@ -103,3 +103,15 @@ class TestRegions(TestCase):
     def test_invalid_region_name(self):
         query = regions.get_region_name(900)
         self.assertIsNone(query)
+
+    def test_fuzzy_match_returns_exact_match(self):
+        result = regions.fuzzy_match("Burkina Faso")
+        self.assertEqual(result, ("BF", True))
+
+    def test_fuzzy_match_returns_fuzzy_match(self):
+        result = regions.fuzzy_match("Upper Volta")
+        self.assertEqual(result, ("BF", False))
+
+    def test_fuzzy_match_returns_no_match(self):
+        result = regions.fuzzy_match("Foobarland")
+        self.assertEqual(result, (None, True))


### PR DESCRIPTION
Turns out `heart` needs the fuzzy matching so I reckon we should add it to the lib.

I noticed while doing this that the way we've structured this means you need to import `regions` to use any of this. I'm wondering if we should ditch the `Regions` class and just have everything as a top-level function? (Perhaps as a new major version of the lib as it would be a breaking change).

Also, the hdx fuzzy matching isn't very fuzzy; it just has some defined regexs for each country. I tried seeing if it would fuzzy match `Amenia`,  and `Armenib` for `Armenia` but it wouldn't.