### PR TITLE
Add function to convert M49 codes to ISO2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.0
+- add function to convert numeric M49 country codes to ISO2 codes
+
 ## 2.0.0
 - restructure library and remove "regions" export
 - add ISO 2-letter codes for regions and sub-regions

--- a/django_countries_hdx/__init__.py
+++ b/django_countries_hdx/__init__.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import TypedDict
+from unicodedata import numeric
 
 from hdx.location.country import Country as HDX
 
@@ -21,6 +22,21 @@ def get_country_data(country_code: str) -> dict[str, str] | None:
         return HDX.get_country_info_from_iso2(country_code)
 
     return HDX.get_country_info_from_iso3(country_code)
+
+def country_iso2_from_m49(country_code: int) -> str | None:
+    """Retrieves annotated country information given a numeric M49 code.
+
+    :param country_code: numeric M49 code.
+    :return: ISO2 code or None.
+    """
+    if country_code is None:
+        return None
+
+    iso3_code = HDX.get_iso3_from_m49(country_code)
+    if iso3_code is None:
+        return None
+
+    return HDX.get_iso2_from_iso3(iso3_code)
 
 def country_region(country) -> int | None:
     """Return a UN M49 region code for a country.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-countries-hdx"
-version = "2.0.0"
+version = "2.1.0"
 description = "Adds extra M49 data to django-countries using hdx-python-country."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_django_countries_hdx.py
+++ b/tests/test_django_countries_hdx.py
@@ -1,6 +1,13 @@
 from unittest import TestCase
-from django_countries_hdx import countries_by_region, countries_by_subregion, fuzzy_match, get_countries_by_region, \
-    get_countries_by_subregion, get_region_name
+from django_countries_hdx import (
+    countries_by_region,
+    countries_by_subregion,
+    country_iso2_from_m49,
+    fuzzy_match,
+    get_countries_by_region,
+    get_countries_by_subregion,
+    get_region_name
+)
 from django_countries.fields import Country
 from django.conf import settings
 
@@ -84,6 +91,18 @@ class TestCountry(TestCase):
     def test_fuzzy_match_returns_no_match(self):
         result = fuzzy_match("Foobarland")
         self.assertEqual(result, (None, True))
+
+    def test_m49_zero_returns_no_match(self):
+        result = country_iso2_from_m49(0)
+        self.assertEqual(result, None)
+
+    def test_m49_valid_returns_match(self):
+        result = country_iso2_from_m49(56)
+        self.assertEqual(result, "BE")
+
+    def test_m49_invalid_returns_no_match(self):
+        result = country_iso2_from_m49(999999)
+        self.assertEqual(result, None)
 
 
 class TestRegions(TestCase):


### PR DESCRIPTION
Some of the NetLoss data imports use M49 numeric country codes.